### PR TITLE
fix param type bug in python 3

### DIFF
--- a/models.py
+++ b/models.py
@@ -4,7 +4,8 @@ slim = tf.contrib.slim
 
 def GeneratorCNN(z, hidden_num, output_num, repeat_num, data_format, reuse):
     with tf.variable_scope("G", reuse=reuse) as vs:
-        x = slim.fully_connected(z, np.prod([8, 8, hidden_num]), activation_fn=None)
+        output_num = int(np.prod([8, 8, hidden_num]))
+        x = slim.fully_connected(z, output_num, activation_fn=None)
         x = reshape(x, 8, 8, hidden_num, data_format)
         
         for idx in range(repeat_num):
@@ -36,7 +37,8 @@ def DiscriminatorCNN(x, input_channel, z_num, repeat_num, hidden_num, data_forma
         z = x = slim.fully_connected(x, z_num, activation_fn=None)
 
         # Decoder
-        x = slim.fully_connected(x, np.prod([8, 8, hidden_num]), activation_fn=None)
+        output_num = int(np.prod([8, 8, hidden_num]))
+        x = slim.fully_connected(x, output_num, activation_fn=None)
         x = reshape(x, 8, 8, hidden_num, data_format)
         
         for idx in range(repeat_num):

--- a/models.py
+++ b/models.py
@@ -4,8 +4,8 @@ slim = tf.contrib.slim
 
 def GeneratorCNN(z, hidden_num, output_num, repeat_num, data_format, reuse):
     with tf.variable_scope("G", reuse=reuse) as vs:
-        output_num = int(np.prod([8, 8, hidden_num]))
-        x = slim.fully_connected(z, output_num, activation_fn=None)
+        num_output = int(np.prod([8, 8, hidden_num]))
+        x = slim.fully_connected(z, num_output, activation_fn=None)
         x = reshape(x, 8, 8, hidden_num, data_format)
         
         for idx in range(repeat_num):
@@ -37,8 +37,8 @@ def DiscriminatorCNN(x, input_channel, z_num, repeat_num, hidden_num, data_forma
         z = x = slim.fully_connected(x, z_num, activation_fn=None)
 
         # Decoder
-        output_num = int(np.prod([8, 8, hidden_num]))
-        x = slim.fully_connected(x, output_num, activation_fn=None)
+        num_output = int(np.prod([8, 8, hidden_num]))
+        x = slim.fully_connected(x, num_output, activation_fn=None)
         x = reshape(x, 8, 8, hidden_num, data_format)
         
         for idx in range(repeat_num):


### PR DESCRIPTION
method numpy.prod returns a numpy.int64 value, which will cause an ValueError in python3. Refer to the following code block in layers.py$fully_connected()

> if not isinstance(num_outputs, six.integer_types):
>     raise ValueError('num_outputs should be int or long, got %s.', num_outputs)

and int() method converts numpy.int64 to be compatible with six.integer_types

This is compatible with python 2
