### PR TITLE
convert float value to int

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -274,7 +274,7 @@ class Trainer(object):
 
     def interpolate_G(self, real_batch, step=0, root_path='.', train_epoch=0):
         batch_size = len(real_batch)
-        half_batch_size = batch_size/2
+        half_batch_size = int(batch_size/2)
 
         self.sess.run(self.z_r_update)
         tf_real_batch = to_nchw_numpy(real_batch)


### PR DESCRIPTION
Unconverted float value will cause error in python 3 since it will be used as indices later.