### PR TITLE
Update trainer.py

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import os
-import StringIO
+#import StringIO
 import scipy.misc
 import numpy as np
 from glob import glob


### PR DESCRIPTION
Remove ‘import StringIO’ . because this module is not used in trainer.py script and it will make an error when using python3.6.
